### PR TITLE
Calculate early slam threshold dynamically

### DIFF
--- a/SlamDelay/SlamDelay.lua
+++ b/SlamDelay/SlamDelay.lua
@@ -144,7 +144,8 @@ function f:COMBAT_LOG_EVENT_UNFILTERED(event)
             end
 
             -- Check for early slams
-            if delay > 3 then
+            local early_slam_threshold = main_speed * 0.8
+            if delay > early_slam_threshold then
                too_early_count = too_early_count + 1
                tooearlylabel:Update()
             end


### PR DESCRIPTION
Use the current swing speed to calculate if a slam was early or not.
The previous constant made early slams non-existant during haste.